### PR TITLE
Fix Sprite collision check

### DIFF
--- a/Space Invaders/Sprite.cs
+++ b/Space Invaders/Sprite.cs
@@ -34,7 +34,7 @@ namespace Space_Invaders
 
         public virtual bool ColisionaCon(Sprite sprite)
         {
-            if((this.x == sprite.x && this.y == sprite.y) || (this.x+1 == sprite.x && this.y+1 == sprite.y)) { return true; }
+            if((this.x == sprite.x && this.y == sprite.y) || (this.x+1 == sprite.x && this.y == sprite.y)) { return true; }
             else { return false; }
         }
     }


### PR DESCRIPTION
## Summary
- correct condition in Sprite.ColisionaCon so Y values match exactly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c2493848832890373f9470d072c1