### PR TITLE
Add unit tests for Sprite collision detection

### DIFF
--- a/Space Invaders/6.11.6 (Space Invaders).sln
+++ b/Space Invaders/6.11.6 (Space Invaders).sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "6.11.6 (Space Invaders)", "6.11.6 (Space Invaders).csproj", "{00723D25-1707-4196-A118-67D67D4234B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpaceInvaders.Tests", "..\SpaceInvaders.Tests\SpaceInvaders.Tests.csproj", "{CA6DC3C0-FDC3-4963-A209-634D1EFAF30A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{00723D25-1707-4196-A118-67D67D4234B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{00723D25-1707-4196-A118-67D67D4234B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00723D25-1707-4196-A118-67D67D4234B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{00723D25-1707-4196-A118-67D67D4234B6}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {00723D25-1707-4196-A118-67D67D4234B6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CA6DC3C0-FDC3-4963-A209-634D1EFAF30A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CA6DC3C0-FDC3-4963-A209-634D1EFAF30A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CA6DC3C0-FDC3-4963-A209-634D1EFAF30A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CA6DC3C0-FDC3-4963-A209-634D1EFAF30A}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/SpaceInvaders.Tests/SpaceInvaders.Tests.csproj
+++ b/SpaceInvaders.Tests/SpaceInvaders.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.9.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Space Invaders/6.11.6 (Space Invaders).csproj" />
+  </ItemGroup>
+</Project>

--- a/SpaceInvaders.Tests/SpriteTests.cs
+++ b/SpaceInvaders.Tests/SpriteTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using Space_Invaders;
+
+namespace SpaceInvaders.Tests
+{
+    public class SpriteTests
+    {
+        [Fact]
+        public void SpriteAtZeroZeroCollidesWithSpriteAtOneZero()
+        {
+            var sprite1 = new Sprite { x = 0, y = 0, Imagen = "A" };
+            var sprite2 = new Sprite { x = 1, y = 0, Imagen = "B" };
+
+            Assert.True(sprite1.ColisionaCon(sprite2));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SpaceInvaders.Tests` project with xUnit
- test `Sprite.ColisionaCon` for neighbouring sprites
- reference new project in the solution

## Testing
- `dotnet test SpaceInvaders.Tests/SpaceInvaders.Tests.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842c24ba7108328ac7950e5a3e17c70