### PR TITLE
Improve enemy movement and game over condition

### DIFF
--- a/Space Invaders/BloqueEnemigos.cs
+++ b/Space Invaders/BloqueEnemigos.cs
@@ -9,6 +9,10 @@ namespace Space_Invaders
     internal class BloqueEnemigos : Enemigo
     {
         public Enemigo[,] enemigos { get; set; }
+        private bool derecha = true;
+        private int desplazamientoY = 0;
+        private readonly int[] baseY = { 5, 7, 9 };
+
         public BloqueEnemigos()
         {
             this.enemigos = new Enemigo[3, 10];
@@ -36,42 +40,49 @@ namespace Space_Invaders
                 enemigos[2, i].Dibujar();
             }
         }
-        bool c = true;
 
         public void MoverBloque()
-        { 
-           if (enemigos[0,0].x == 1)
-           {
-                c = true;
-           }
-
-            if (enemigos[0,9].x == 118)
+        {
+            if (derecha && enemigos[0, 9].x >= 118)
             {
-                c = false;
+                derecha = false;
+                desplazamientoY++;
+            }
+
+            if (!derecha && enemigos[0, 0].x <= 1)
+            {
+                derecha = true;
+                desplazamientoY++;
             }
 
             BorrarBloque();
 
-            if (c)
-            {
-                for(int i = 0; i < enemigos.GetLength(1); i++)
-                {
-                    enemigos[0, i].MoverA(enemigos[0, i].x + 1, 5);
-                    enemigos[1, i].MoverA(enemigos[1, i].x + 1, 7);
-                    enemigos[2, i].MoverA(enemigos[2, i].x + 1, 9);
-                }
-            }
-            else
+            for (int fila = 0; fila < enemigos.GetLength(0); fila++)
             {
                 for (int i = 0; i < enemigos.GetLength(1); i++)
                 {
-                    enemigos[0, i].MoverA(enemigos[0, i].x - 1, 5);
-                    enemigos[1, i].MoverA(enemigos[1, i].x - 1, 7);
-                    enemigos[2, i].MoverA(enemigos[2, i].x - 1, 9);                   
+                    int nuevoX = derecha ? enemigos[fila, i].x + 1 : enemigos[fila, i].x - 1;
+                    int nuevoY = baseY[fila] + desplazamientoY;
+                    enemigos[fila, i].MoverA(nuevoX, nuevoY);
                 }
             }
+
             Dibujar();
         }
+
+        public int PosicionYInferior()
+        {
+            int max = 0;
+            for (int i = 0; i < enemigos.GetLength(1); i++)
+            {
+                if (enemigos[2, i].Activo && enemigos[2, i].y > max)
+                {
+                    max = enemigos[2, i].y;
+                }
+            }
+            return max;
+        }
+        
 
         public void BorrarBloque()
         {

--- a/Space Invaders/Partida.cs
+++ b/Space Invaders/Partida.cs
@@ -27,10 +27,15 @@ namespace Space_Invaders
             bool poderDisparar = true, poderDispararEnemigo = true;
             int xEnemigo = 0, yEnemigo = 0;
             int enemigosMuertos = 0;
+            bool invasion = false;
             do
             {
                 Thread.Sleep(50);
                 bloqueEnemigos.MoverBloque();
+                if (bloqueEnemigos.PosicionYInferior() >= 20)
+                {
+                    invasion = true;
+                }
                 nave.Dibujar();
                 ovni.Mover();
                 marcador.Dibujar();
@@ -101,9 +106,9 @@ namespace Space_Invaders
                     if (tecla.Key == ConsoleKey.RightArrow) { nave.MoverDerecha(); }
                     if (poderDisparar) { if (tecla.Key == ConsoleKey.Spacebar) { disparo.Lanzar(nave.x,Y, ref poderDisparar); } }
                 }  
-            } while(tecla.Key != ConsoleKey.Escape && marcador.Vidas != 0 && enemigosMuertos != 30);
+            } while(tecla.Key != ConsoleKey.Escape && marcador.Vidas != 0 && enemigosMuertos != 30 && !invasion);
 
-            if (marcador.Vidas == 0)
+            if (marcador.Vidas == 0 || invasion)
             {
                 Console.Clear();
                 Console.SetCursorPosition(50, 10);


### PR DESCRIPTION
## Summary
- move enemy block downward when reaching screen edges
- track lowest enemy position to detect invasion
- end the game if enemies reach the defenses

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3ba3e8083289f04200d100cfcf2